### PR TITLE
Fixed ports fields in prod-cart-node

### DIFF
--- a/docker-compose-linux.yml
+++ b/docker-compose-linux.yml
@@ -61,7 +61,7 @@ services:
             context: https://raw.githubusercontent.com/nmarsollier/ecommerce_cart_node/master/Dockerfile.prod
         extra_hosts:
             - "host.docker.internal:172.17.0.1"
-        environment:
+        ports:
             - '3003:3003'
         image: prod-cart-node
         depends_on:

--- a/docker-compose-prod-linux.yml
+++ b/docker-compose-prod-linux.yml
@@ -53,7 +53,7 @@ services:
     container_name: prod-cart-node
     extra_hosts:
       - "host.docker.internal:172.17.0.1"
-    environment:
+    ports:
       - "3003:3003"
     image: nmarsollier/prod-cart-node:v1.0
     depends_on:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -44,7 +44,7 @@ services:
       - "mongo"
   prod-cart-node:
     container_name: prod-cart-node
-    environment:
+    ports:
       - "3003:3003"
     image: nmarsollier/prod-cart-node:v1.0
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
         container_name: prod-cart-node
         build:
             context: https://raw.githubusercontent.com/nmarsollier/ecommerce_cart_node/master/Dockerfile.prod
-        environment:
+        ports:
             - '3003:3003'
         image: prod-cart-node
         depends_on:


### PR DESCRIPTION
Intentando levantar el repo de ecommerce, me di cuenta que el microservicio de cart no exponía puertos cuando lo levantaba. Creo que eso soluciona el problema, habría que cambiarlo en los archivos docker-compose*.yml